### PR TITLE
fix spelling errors

### DIFF
--- a/pci.ids
+++ b/pci.ids
@@ -12123,7 +12123,7 @@
 1138  Ziatech Corporation
 	8905  8905 [STD 32 Bridge]
 1139  Dynamic Pictures, Inc
-	0001  VGA Compatable 3D Graphics
+	0001  VGA Compatible 3D Graphics
 113a  FWB Inc
 113b  Network Computing Devices
 113c  Cyclone Microsystems, Inc.
@@ -22436,7 +22436,7 @@
 	208e  Sky Lake-E CHA Registers
 	2250  Xeon Phi coprocessor 5100 series
 	225c  Xeon Phi coprocessor SE10/7120 series
-	225d  Xeon Phi coprocessor 3120 series 
+	225d  Xeon Phi coprocessor 3120 series
 	225e  Xeon Phi coprocessor 31S1
 	2310  DH89xxCC LPC Controller
 	2323  DH89xxCC 4 Port SATA AHCI Controller
@@ -26552,7 +26552,7 @@
 8686  ScaleMP
 	1010  vSMPowered system controller [vSMP CTL]
 8800  Trigem Computer Inc.
-	2008  Video assistent component
+	2008  Video assistant component
 8866  T-Square Design Inc.
 8888  Silicon Magic
 8912  TRX


### PR DESCRIPTION
Hi!

I'm not sure that the right way to fix this (this repo seems to be only a mirror / auto-generated), but in Debian packaging of hwinfo we discovered some spelling typos (please see https://github.com/openSUSE/hwinfo/pull/16).

Thanks,
