### PR TITLE
Dell BOSS controller sub-vendor ID and sub-device ID

### DIFF
--- a/pci.ids
+++ b/pci.ids
@@ -1121,6 +1121,7 @@
 		1028 2174  PERC H350 Mini
 		1028 2177  PERC H350 Adapter
 		1028 2199  PERC H350 Mini LP
+		1028 1a3d  BOSS-MR1
 		15d9 1b9d  AOC-S3816L-L16IR Storage Adapter
 		15d9 1b9f  AOC-S3816L-L8IR Storage Adapter
 		15d9 1c6d  AOC-S3808L-L8IR Storage Adapter


### PR DESCRIPTION
add 1028:1a3d

Dell sub-vendor ID and sub-device ID

for BOSS controller BOSS-MR1 